### PR TITLE
Workaround for statvfs handling UTF-8 path string

### DIFF
--- a/timewarp.py
+++ b/timewarp.py
@@ -22,7 +22,7 @@ import json
 def df(path):
     """ Return the free disk space (in Mb) at the specified path
     """
-    st = os.statvfs(path)
+    st = os.statvfs(path.encode('utf8'))
     free = (st.f_bavail * st.f_frsize) / 1024 / 1024
 
     return free


### PR DESCRIPTION
A small tweak to workaround this error by UTF-8 encoding the path string prior to passing it to statvfs
  File "./timewarp.py", line 25, in df
    st = os.statvfs(path)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2019' in position 51: ordinal not in range(128)

Via https://code.google.com/p/psutil/issues/detail?id=416
